### PR TITLE
 - Fixed problem with figcaption on bottom not working.

### DIFF
--- a/markdown_extended.php
+++ b/markdown_extended.php
@@ -136,7 +136,7 @@ class MarkdownExtraExtended_Parser extends MarkdownExtra_Parser {
 	function _doFencedFigures_callback($matches) {
 		# get figcaption
 		$topcaption = empty($matches[2]) ? null : $this->runBlockGamut($matches[2]);
-		$bottomcaption = empty($matches[4]) ? null : $this->runBlockGamut($matches[4]);
+		$bottomcaption = empty($matches[5]) ? null : $this->runBlockGamut($matches[5]);
 		$figure = $matches[3];
 		$figure = $this->runBlockGamut($figure); # recurse
 


### PR DESCRIPTION
I noticed there was a bug in the logic to process the fenced figures such that it was not correctly grabbing the caption and outputting it in the HTML when it was at the bottom of the figure.

Here is a test that can be used to test the behavior in question:

``` php
<?php

require_once 'markdown_extended.php';

$markdown = "
===
![](img/reference.png)
=== [A **happy face** is good for web developers]
";

// Convert markdown formatted text in $markdown to HTML
$html = MarkdownExtended($markdown);
echo $html;
```

I have experienced this and tested the fix in PHP version 5.4.6
