### PR TITLE
Support for strikethrough, same as GFM

### DIFF
--- a/markdown_extended.php
+++ b/markdown_extended.php
@@ -18,7 +18,9 @@ class MarkdownExtraExtended_Parser extends MarkdownExtra_Parser {
 		$this->block_gamut += array(
 			"doFencedFigures" => 7,
 		);
-		
+		$this->span_gamut += array(
+			"doStrikethroughs" => -35
+		);
 		parent::MarkdownExtra_Parser();
 	}
 	
@@ -156,6 +158,20 @@ class MarkdownExtraExtended_Parser extends MarkdownExtra_Parser {
 		}
 		$res .= "</figure>";		
 		return "\n". $this->hashBlock($res)."\n\n";
+	}
+	function doStrikethroughs($text) {
+	#
+	# Replace ~~some deleted text~~ with <del>some deleted text</del>
+	#
+		$text = preg_replace_callback('{
+				~~([^~]+)~~
+			}xm',
+			array(&$this, '_doStrikethroughs_callback'), $text);
+		return $text;
+	}
+	function _doStrikethroughs_callback($matches) {
+		$res = "<del>" . $matches[1] . "</del>";
+		return $this->hashBlock($res);
 	}
 }
 ?>


### PR DESCRIPTION
Adds syntax to create strikethrough text, replace `~~deleted text~~` with `<del>deleted text</del>`, just
like GFM's strikethrough syntax (https://help.github.com/articles/github-flavored-markdown/#strikethrough)

Hope that's useful!
